### PR TITLE
Allow for submenu expansion and link navigation depending on which child element of the link is click

### DIFF
--- a/src/scripts/modules/expanders.ts
+++ b/src/scripts/modules/expanders.ts
@@ -14,7 +14,7 @@
 export default function setupExpanders() {
     const expanders = Array.from(document.querySelectorAll("#menu .submenu-item"));
     for (const ex of expanders) {
-        ex.addEventListener("click", e => {
+        ex.addEventListener("mouseover", e => {
             if ((e.target as Element).closest(".submenu-item,.item") !== ex) return;
             e.preventDefault();
             e.stopPropagation();

--- a/src/scripts/modules/expanders.ts
+++ b/src/scripts/modules/expanders.ts
@@ -14,8 +14,6 @@
 function setupExpanders() {
   const expanders = Array.from(document.querySelectorAll("#menu .submenu-item button"));
   for (const ex of expanders) {
-      console.log(ex.classList);
-      console.log(ex.parentElement.parentElement.classList);
     ex.addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();

--- a/src/scripts/modules/expanders.ts
+++ b/src/scripts/modules/expanders.ts
@@ -20,7 +20,7 @@ function setupExpanders() {
       const ul = ex.parentElement.parentElement;
       ul.style.height = `${ul.scrollHeight}px`;
       setTimeout(() => ul.classList.toggle("expanded"), 1);
-      setTimeout(() => ul.style.height = ``, 200);
+      setTimeout(() => ul.style.height = ``, 1);
     });
   }
 }

--- a/src/scripts/modules/expanders.ts
+++ b/src/scripts/modules/expanders.ts
@@ -11,17 +11,18 @@
 //     }
 // }
 
-export default function setupExpanders() {
-    const expanders = Array.from(document.querySelectorAll("#menu .submenu-item"));
-    for (const ex of expanders) {
-        ex.addEventListener("mouseover", e => {
-            if ((e.target as Element).closest(".submenu-item,.item") !== ex) return;
-            e.preventDefault();
-            e.stopPropagation();
-            const ul = ex.querySelector("ul")!;
-            ul.style.height = `${ul.scrollHeight}px`;
-            setTimeout(() => ex.classList.toggle("expanded"), 1);
-            setTimeout(() => ul.style.height = ``, 200);
-        });
-    }
+function setupExpanders() {
+  const expanders = Array.from(document.querySelectorAll("#menu .submenu-item button"));
+  for (const ex of expanders) {
+      console.log(ex.classList);
+      console.log(ex.parentElement.parentElement.classList);
+    ex.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const ul = ex.parentElement.parentElement;
+      ul.style.height = `${ul.scrollHeight}px`;
+      setTimeout(() => ul.classList.toggle("expanded"), 1);
+      setTimeout(() => ul.style.height = ``, 200);
+    });
+  }
 }


### PR DESCRIPTION
Let me know if I should delete this. I'm not sure if this PR belongs here or in [zerebos' repo](https://github.com/zerebos/trilium.rocks) (it's there too, just in case).

This change targets the button of the submenu item rather than the submenu item itself, so that the span title can still function as a link.
